### PR TITLE
CSS hyperlink reference error

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Buổi 9 - SCSS coding</title>
-    <link rel="stylesheet" href="./resources/css/style.css">
+    <link rel="stylesheet" href="./style.css">
 </head>
 <body>
     <div class="heading">


### PR DESCRIPTION
change from
```
<link rel="stylesheet" href="./resources/css/style.css">
```
to
```
<link rel="stylesheet" href="./style.css">
```